### PR TITLE
feat: support for direct upgrades between multiple versions

### DIFF
--- a/pkg/reconciler/common/direct_upgrade.go
+++ b/pkg/reconciler/common/direct_upgrade.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+const (
+	// DirectUpgradeVersionsEnvKey is the key of the environment variable to specify the direct upgrade versions
+	DirectUpgradeVersionsEnvKey = "DIRECT_UPGRADE_VERSIONS"
+	// DefaultDirectUpgradeVersions is the default direct upgrade versions
+	// Use `-` to separate the versions that can be upgraded directly
+	// Use `|` to separate between pairs of versions
+	DefaultDirectUpgradeVersions = "v0.24-v1.2"
+)
+
+var (
+	directUpgradeVersionsString string = DefaultDirectUpgradeVersions
+	directUpgradeVersions       [][2]string
+)
+
+func init() {
+	envInit()
+}
+
+// envInit get the direct upgrade versions from environment variable and parse it
+func envInit() {
+	directUpgradeVersions = [][2]string{}
+
+	// get the direct upgrade versions from environment variable
+	if v := os.Getenv(DirectUpgradeVersionsEnvKey); v != "" {
+		directUpgradeVersionsString = v
+	}
+
+	// parse the direct upgrade versions
+	versions := strings.Split(directUpgradeVersionsString, "|")
+	for _, v := range versions {
+		pair := strings.Split(v, "-")
+		if len(pair) != 2 {
+			log.Printf("Wrong direct upgrade versions configuration %q\n", v)
+			continue
+		}
+		directUpgradeVersions = append(directUpgradeVersions, [2]string{pair[0], pair[1]})
+	}
+	log.Printf("Direct upgrade versions: %+v\n", directUpgradeVersions)
+}
+
+// isDirectUpgradeVersion returns true if the version is in the direct upgrade list
+func isDirectUpgradeVersion(from, to string) bool {
+	for _, v := range directUpgradeVersions {
+		// upgrade
+		if v[0] == from && v[1] == to {
+			return true
+		}
+		// downgrade
+		if v[1] == from && v[0] == to {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconciler/common/direct_upgrade_test.go
+++ b/pkg/reconciler/common/direct_upgrade_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_isDirectUpgradeVersion(t *testing.T) {
+
+	t.Log("use default versions")
+	envInit()
+	if !isDirectUpgradeVersion("v0.24", "v1.2") {
+		t.Error("isDirectUpgradeVersion should return true")
+	}
+	if !isDirectUpgradeVersion("v1.2", "v0.24") {
+		t.Error("isDirectUpgradeVersion should return true")
+	}
+
+	t.Log("use specify versions")
+	os.Setenv("DIRECT_UPGRADE_VERSIONS", "v0.1-v0.2")
+	envInit()
+	if isDirectUpgradeVersion("v0.24", "v1.2") {
+		t.Error("isDirectUpgradeVersion should return false")
+	}
+	if !isDirectUpgradeVersion("v0.2", "v0.1") {
+		t.Error("isDirectUpgradeVersion should return true")
+	}
+	if !isDirectUpgradeVersion("v0.1", "v0.2") {
+		t.Error("isDirectUpgradeVersion should return true")
+	}
+
+	t.Log("use multiple versions")
+	os.Setenv("DIRECT_UPGRADE_VERSIONS", "v0.1-v0.2|v1.0-v2.0")
+	envInit()
+	if isDirectUpgradeVersion("v0.24", "v1.2") {
+		t.Error("isDirectUpgradeVersion should return false")
+	}
+	if !isDirectUpgradeVersion("v0.2", "v0.1") {
+		t.Error("isDirectUpgradeVersion should return true")
+	}
+	if !isDirectUpgradeVersion("v1.0", "v2.0") {
+		t.Error("isDirectUpgradeVersion should return true")
+	}
+
+	t.Log("use invalid format version")
+	os.Setenv("DIRECT_UPGRADE_VERSIONS", "v0.1-v0.2-v0.3")
+	envInit()
+	if isDirectUpgradeVersion("v0.24", "v1.2") {
+		t.Error("isDirectUpgradeVersion should return false")
+	}
+}

--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -19,6 +19,7 @@ package common
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -151,6 +152,12 @@ func IsVersionValidMigrationEligible(instance v1alpha1.KComponent) error {
 	targetMinor, err := strconv.Atoi(strings.Split(target, ".")[1])
 	if err != nil {
 		return fmt.Errorf("minor number of the target version %v should be an integer.", target)
+	}
+
+	// If the version is in the direct upgrade list, return nil.
+	if isDirectUpgradeVersion(semver.MajorMinor(current), semver.MajorMinor(target)) {
+		log.Printf("Direct upgrade %s/%s from %s to %s\n", instance.GetNamespace(), instance.GetName(), current, target)
+		return nil
 	}
 
 	if currentMajor != targetMajor {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Base branch is https://github.com/katanomi/knative-operator/tree/knative-v1.2.0

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
support for direct upgrades between multiple versions
```
