### PR TITLE
Add migration for updating KnativeEventing spec.version to empty

### DIFF
--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -74,6 +74,8 @@ func TargetVersion(instance base.KComponent) string {
 		}
 	}
 
+	logger.Infow("Manifests length is not 0", "version", version)
+
 	return version
 }
 

--- a/pkg/reconciler/knativeeventing/common/migrate_katanomi.go
+++ b/pkg/reconciler/knativeeventing/common/migrate_katanomi.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/operator/pkg/client/clientset/versioned"
+	"knative.dev/pkg/logging"
+)
+
+var (
+	annotationDisableMigrateAutoUpgrade = "katanomi.dev/disable-migrate-auto-upgrade"
+)
+
+// MigrateEventingSpecVersion will set `spec.version` to empty for all KnativeEventings
+// if KnativeEventing has an annotation katanomi.dev/disable-migrate-auto-upgrade, it will just skip migration
+func MigrateEventingSpecVersion(ctx context.Context, operatorClient versioned.Interface) error {
+	logger := logging.FromContext(ctx).With("name", "migrate-eventing-specversion")
+	logger.Info("Migrating the existing KnativeEventing instances")
+	eventings, err := operatorClient.OperatorV1beta1().KnativeEventings("").List(ctx, metav1.ListOptions{
+		ResourceVersion: "0",
+	})
+	if err != nil {
+		return err
+	}
+	if len(eventings.Items) == 0 {
+		logger.Debugw("there is no knative eventings need to migrate spec.version")
+		return nil
+	}
+
+	for _, eventing := range eventings.Items {
+		if eventing.Annotations != nil {
+			if _, ok := eventing.Annotations[annotationDisableMigrateAutoUpgrade]; ok {
+				logger.Debugw("skip eventing", "eventing", eventing.Namespace+"/"+eventing.Name)
+				continue
+			}
+		}
+		if eventing.Spec.Version == "" {
+			continue
+		}
+
+		patch := `{"spec":{"version": ""}}`
+		_, err = operatorClient.OperatorV1beta1().KnativeEventings(eventing.Namespace).Patch(
+			ctx, eventing.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
+		if err != nil {
+			logger.Errorw("error to update spec.version to empty", "err", err)
+			continue
+		}
+		logger.Infow("migrated spec.version to empty", "eventing", eventing.Namespace+"/"+eventing.Name)
+	}
+
+	return nil
+}

--- a/pkg/reconciler/knativeeventing/common/migrate_katanomi_test.go
+++ b/pkg/reconciler/knativeeventing/common/migrate_katanomi_test.go
@@ -1,0 +1,165 @@
+package common
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/operator/pkg/apis/operator/base"
+	"knative.dev/operator/pkg/apis/operator/v1beta1"
+	fakeclientset "knative.dev/operator/pkg/client/clientset/versioned/fake"
+	"knative.dev/pkg/logging"
+	"testing"
+)
+
+func TestMigrateEventingSpecVersion(t *testing.T) {
+
+	var tests = []struct {
+		desc      string
+		eventings []runtime.Object
+
+		expectedSpecVersion map[string]string
+	}{
+		{
+			desc:                "no eventings is cluster",
+			expectedSpecVersion: map[string]string{},
+		},
+
+		{
+			desc: "only one eventings",
+			eventings: []runtime.Object{
+				&v1beta1.KnativeEventing{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: "ns1",
+					},
+					Spec: v1beta1.KnativeEventingSpec{
+						CommonSpec: base.CommonSpec{
+							Version: "v1.0",
+						},
+					},
+				},
+			},
+			expectedSpecVersion: map[string]string{
+				"ns1/default": "",
+			},
+		},
+
+		{
+			desc: "more than one eventings",
+			eventings: []runtime.Object{
+				&v1beta1.KnativeEventing{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-empty",
+						Namespace: "ns1",
+					},
+					Spec: v1beta1.KnativeEventingSpec{
+						CommonSpec: base.CommonSpec{
+							Version: "v1.0",
+						},
+					},
+				},
+				&v1beta1.KnativeEventing{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "empty",
+						Namespace: "ns2",
+					},
+					Spec: v1beta1.KnativeEventingSpec{
+						CommonSpec: base.CommonSpec{
+							Version: "",
+						},
+					},
+				},
+				&v1beta1.KnativeEventing{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-empty",
+						Namespace: "ns2",
+					},
+					Spec: v1beta1.KnativeEventingSpec{
+						CommonSpec: base.CommonSpec{
+							Version: "v2.0",
+						},
+					},
+				},
+				&v1beta1.KnativeEventing{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "empty",
+						Namespace: "skip-migrate-ns",
+						Annotations: map[string]string{
+							annotationDisableMigrateAutoUpgrade: "true",
+						},
+					},
+					Spec: v1beta1.KnativeEventingSpec{
+						CommonSpec: base.CommonSpec{
+							Version: "",
+						},
+					},
+				},
+				&v1beta1.KnativeEventing{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not-empty",
+						Namespace: "skip-migrate-ns",
+						Annotations: map[string]string{
+							annotationDisableMigrateAutoUpgrade: "true",
+						},
+					},
+					Spec: v1beta1.KnativeEventingSpec{
+						CommonSpec: base.CommonSpec{
+							Version: "v1.0",
+						},
+					},
+				},
+			},
+			expectedSpecVersion: map[string]string{
+				"ns1/not-empty":             "",
+				"ns2/empty":                 "",
+				"ns2/not-empty":             "",
+				"skip-migrate-ns/empty":     "",
+				"skip-migrate-ns/not-empty": "v1.0",
+			},
+		},
+	}
+
+	for _, item := range tests {
+
+		t.Run(item.desc, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, log)
+
+			objs := []runtime.Object{}
+			if item.eventings != nil {
+				objs = append(objs, item.eventings...)
+			}
+			client := fakeclientset.NewSimpleClientset(objs...)
+
+			err := MigrateEventingSpecVersion(ctx, client)
+			if err != nil {
+				t.Errorf("should migrate succeed: %s", err.Error())
+			}
+
+			all, err := client.OperatorV1beta1().KnativeEventings("").List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+			if err != nil {
+				t.Errorf("list eventings error: %s", err.Error())
+			}
+
+			actualSpecVersion := map[string]string{}
+			for _, eventing := range all.Items {
+				actualSpecVersion[eventing.Namespace+"/"+eventing.Name] = eventing.Spec.Version
+			}
+
+			if len(actualSpecVersion) != len(item.expectedSpecVersion) {
+				t.Errorf("length should be equal, actual: %d, expected: %d", len(actualSpecVersion), len(item.expectedSpecVersion))
+			}
+			for key, actualValue := range actualSpecVersion {
+				var ok bool
+				actualValue, ok = item.expectedSpecVersion[key]
+				if !ok {
+					t.Errorf("should not contains knativeeventing `%s`", key)
+				}
+
+				if actualValue != item.expectedSpecVersion[key] {
+					t.Errorf("expect `spec.version` of knativeeventing '%s' should be '%s' but got '%s' ", key, item.expectedSpecVersion[key], actualValue)
+				}
+			}
+		})
+	}
+}

--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -28,6 +28,7 @@ import (
 	knativeEventinginformer "knative.dev/operator/pkg/client/injection/informers/operator/v1beta1/knativeeventing"
 	knereconciler "knative.dev/operator/pkg/client/injection/reconciler/operator/v1beta1/knativeeventing"
 	"knative.dev/operator/pkg/reconciler/common"
+	eventingcommon "knative.dev/operator/pkg/reconciler/knativeeventing/common"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	"knative.dev/pkg/configmap"
@@ -78,6 +79,12 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		if err != nil {
 			logger.Fatalw("Unable to migrate existing custom resources", zap.Error(err))
 		}
+
+		err = eventingcommon.MigrateEventingSpecVersion(ctx, operatorclient.Get(ctx))
+		if err != nil {
+			logger.Errorw("migrate knativeeventing spec.version error", "err", err)
+		}
+
 		return impl
 	}
 }


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

1. migrate KnativeEventing spec.version to empty, so, we could upgrade KnativeEventing auto

**Release Note**

```release-note
NONE
```
