### PR TITLE
fix: update conversion webhook patch and apply TLS configuration changes

### DIFF
--- a/hack/patches/006-conversion-webhook.patch
+++ b/hack/patches/006-conversion-webhook.patch
@@ -1,58 +1,35 @@
-Subject: [PATCH] fix: add environment parameter to control the use of OLM TLS.
----
-Index: vendor/knative.dev/pkg/webhook/webhook.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/vendor/knative.dev/pkg/webhook/webhook.go b/vendor/knative.dev/pkg/webhook/webhook.go
---- a/vendor/knative.dev/pkg/webhook/webhook.go	(revision 135ea9775cbae2a3b5e02e2cd11697ea41576efe)
-+++ b/vendor/knative.dev/pkg/webhook/webhook.go	(date 1726155195856)
-@@ -24,6 +24,7 @@
- 	"html"
+index eff693e80..05b5f44ca 100644
+--- a/vendor/knative.dev/pkg/webhook/webhook.go
++++ b/vendor/knative.dev/pkg/webhook/webhook.go
+@@ -25,6 +25,7 @@ import (
+ 	"log"
+ 	"net"
  	"net/http"
- 	"time"
 +	"os"
+ 	"time"
  
  	// Injection stuff
- 
-@@ -145,27 +146,43 @@
- 		// informer, then we can fetch the shared informer factory here and produce
+@@ -174,27 +175,45 @@ func New(
  		// a new secret informer from it.
  		secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
--
+ 
 -		webhook.tlsConfig = &tls.Config{
 -			MinVersion: opts.TLSMinVersion,
--
--			// If we return (nil, error) the client sees - 'tls: internal error"
--			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
--			//
--			// We'll return (nil, nil) when we don't find a certificate
--			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
--				secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
--				if err != nil {
--					logger.Errorw("failed to fetch secret", zap.Error(err))
--					return nil, nil
--				}
--
--				serverKey, ok := secret.Data[certresources.ServerKey]
--				if !ok {
--					logger.Warn("server key missing")
--					return nil, nil
--				}
--				serverCert, ok := secret.Data[certresources.ServerCert]
 +		var getCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 +			secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
 +			if err != nil {
 +				logger.Errorw("failed to fetch secret", zap.Error(err))
 +				return nil, nil
 +			}
-+			serverKey, ok := secret.Data[certresources.ServerKey]
++			webOpts := GetOptions(ctx)
++			sKey, sCert := getSecretDataKeyNamesOrDefault(webOpts.ServerPrivateKeyName, webOpts.ServerCertificateName)
++			serverKey, ok := secret.Data[sKey]
 +			if !ok {
 +				logger.Warn("server key missing")
 +				return nil, nil
 +			}
-+			serverCert, ok := secret.Data[certresources.ServerCert]
++			serverCert, ok := secret.Data[sCert]
 +			if !ok {
 +				logger.Warn("server cert missing")
 +				return nil, nil
@@ -63,25 +40,34 @@ diff --git a/vendor/knative.dev/pkg/webhook/webhook.go b/vendor/knative.dev/pkg/
 +			}
 +			return &cert, nil
 +		}
-+
+ 
+-			// If we return (nil, error) the client sees - 'tls: internal error"
+-			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
+-			//
+-			// We'll return (nil, nil) when we don't find a certificate
+-			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 +		if os.Getenv("USE_OLM_TLS") != "" {
 +			getCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-+				secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
-+				if err != nil {
-+					logger.Errorw("failed to fetch secret", zap.Error(err))
-+					return nil, nil
-+				}
+ 				secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
+ 				if err != nil {
+ 					logger.Errorw("failed to fetch secret", zap.Error(err))
+ 					return nil, nil
+ 				}
+-				webOpts := GetOptions(ctx)
+-				sKey, sCert := getSecretDataKeyNamesOrDefault(webOpts.ServerPrivateKeyName, webOpts.ServerCertificateName)
+-				serverKey, ok := secret.Data[sKey]
 +
 +				serverKey, ok := secret.Data["tls.key"]
-+				if !ok {
-+					logger.Warn("server key missing")
-+					return nil, nil
-+				}
+ 				if !ok {
+ 					logger.Warn("server key missing")
+ 					return nil, nil
+ 				}
+-				serverCert, ok := secret.Data[sCert]
 +				serverCert, ok := secret.Data["tls.crt"]
  				if !ok {
  					logger.Warn("server cert missing")
  					return nil, nil
-@@ -175,7 +192,17 @@
+@@ -204,7 +223,17 @@ func New(
  					return nil, err
  				}
  				return &cert, nil

--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 update-deps:
-	git apply hack/patches/*
+	git apply hack/patches/*.patch

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/conversion/reconciler.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/conversion/reconciler.go
@@ -19,6 +19,7 @@ package conversion
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"go.uber.org/zap"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -73,6 +74,10 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	if err != nil {
 		logger.Errorw("Error fetching secret", zap.Error(err))
 		return err
+	}
+
+	if os.Getenv("USE_OLM_TLS") != "" { // olm will do the crd update
+		return nil
 	}
 
 	cacert, ok := secret.Data[certresources.CACert]

--- a/vendor/knative.dev/pkg/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/webhook/webhook.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	// Injection stuff
@@ -174,27 +175,45 @@ func New(
 		// a new secret informer from it.
 		secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
 
-		webhook.tlsConfig = &tls.Config{
-			MinVersion: opts.TLSMinVersion,
+		var getCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
+			if err != nil {
+				logger.Errorw("failed to fetch secret", zap.Error(err))
+				return nil, nil
+			}
+			webOpts := GetOptions(ctx)
+			sKey, sCert := getSecretDataKeyNamesOrDefault(webOpts.ServerPrivateKeyName, webOpts.ServerCertificateName)
+			serverKey, ok := secret.Data[sKey]
+			if !ok {
+				logger.Warn("server key missing")
+				return nil, nil
+			}
+			serverCert, ok := secret.Data[sCert]
+			if !ok {
+				logger.Warn("server cert missing")
+				return nil, nil
+			}
+			cert, err := tls.X509KeyPair(serverCert, serverKey)
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		}
 
-			// If we return (nil, error) the client sees - 'tls: internal error"
-			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
-			//
-			// We'll return (nil, nil) when we don't find a certificate
-			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		if os.Getenv("USE_OLM_TLS") != "" {
+			getCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 				secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
 				if err != nil {
 					logger.Errorw("failed to fetch secret", zap.Error(err))
 					return nil, nil
 				}
-				webOpts := GetOptions(ctx)
-				sKey, sCert := getSecretDataKeyNamesOrDefault(webOpts.ServerPrivateKeyName, webOpts.ServerCertificateName)
-				serverKey, ok := secret.Data[sKey]
+
+				serverKey, ok := secret.Data["tls.key"]
 				if !ok {
 					logger.Warn("server key missing")
 					return nil, nil
 				}
-				serverCert, ok := secret.Data[sCert]
+				serverCert, ok := secret.Data["tls.crt"]
 				if !ok {
 					logger.Warn("server cert missing")
 					return nil, nil
@@ -204,7 +223,17 @@ func New(
 					return nil, err
 				}
 				return &cert, nil
-			},
+			}
+		}
+
+		webhook.tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+
+			// If we return (nil, error) the client sees - 'tls: internal error"
+			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
+			//
+			// We'll return (nil, nil) when we don't find a certificate
+			GetCertificate: getCertificate,
 		}
 	}
 


### PR DESCRIPTION
Updates the webhook patch to support OLM TLS configuration and fixes makefile to properly apply patch files.

sync from: https://github.com/katanomi/knative-operator/pull/13/files

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
