### PR TITLE
fix: restore USE_OLM_TLS vendor patches dropped by vuln-0512

### DIFF
--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/conversion/reconciler.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/conversion/reconciler.go
@@ -19,6 +19,7 @@ package conversion
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"go.uber.org/zap"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -73,6 +74,10 @@ func (r *reconciler) Reconcile(ctx context.Context, key string) error {
 	if err != nil {
 		logger.Errorw("Error fetching secret", zap.Error(err))
 		return err
+	}
+
+	if os.Getenv("USE_OLM_TLS") != "" { // olm will do the crd update
+		return nil
 	}
 
 	cacert, ok := secret.Data[certresources.CACert]

--- a/vendor/knative.dev/pkg/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/webhook/webhook.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	// Injection stuff
@@ -174,27 +175,45 @@ func New(
 		// a new secret informer from it.
 		secretInformer := kubeinformerfactory.Get(ctx).Core().V1().Secrets()
 
-		webhook.tlsConfig = &tls.Config{
-			MinVersion: opts.TLSMinVersion,
+		var getCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
+			if err != nil {
+				logger.Errorw("failed to fetch secret", zap.Error(err))
+				return nil, nil
+			}
+			webOpts := GetOptions(ctx)
+			sKey, sCert := getSecretDataKeyNamesOrDefault(webOpts.ServerPrivateKeyName, webOpts.ServerCertificateName)
+			serverKey, ok := secret.Data[sKey]
+			if !ok {
+				logger.Warn("server key missing")
+				return nil, nil
+			}
+			serverCert, ok := secret.Data[sCert]
+			if !ok {
+				logger.Warn("server cert missing")
+				return nil, nil
+			}
+			cert, err := tls.X509KeyPair(serverCert, serverKey)
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		}
 
-			// If we return (nil, error) the client sees - 'tls: internal error"
-			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
-			//
-			// We'll return (nil, nil) when we don't find a certificate
-			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		if os.Getenv("USE_OLM_TLS") != "" {
+			getCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 				secret, err := secretInformer.Lister().Secrets(system.Namespace()).Get(opts.SecretName)
 				if err != nil {
 					logger.Errorw("failed to fetch secret", zap.Error(err))
 					return nil, nil
 				}
-				webOpts := GetOptions(ctx)
-				sKey, sCert := getSecretDataKeyNamesOrDefault(webOpts.ServerPrivateKeyName, webOpts.ServerCertificateName)
-				serverKey, ok := secret.Data[sKey]
+
+				serverKey, ok := secret.Data["tls.key"]
 				if !ok {
 					logger.Warn("server key missing")
 					return nil, nil
 				}
-				serverCert, ok := secret.Data[sCert]
+				serverCert, ok := secret.Data["tls.crt"]
 				if !ok {
 					logger.Warn("server cert missing")
 					return nil, nil
@@ -204,7 +223,17 @@ func New(
 					return nil, err
 				}
 				return &cert, nil
-			},
+			}
+		}
+
+		webhook.tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+
+			// If we return (nil, error) the client sees - 'tls: internal error"
+			// If we return (nil, nil) the client sees - 'tls: no certificates configured'
+			//
+			// We'll return (nil, nil) when we don't find a certificate
+			GetCertificate: getCertificate,
 		}
 	}
 


### PR DESCRIPTION
## Summary

Re-applies PR #25 (`fix: using olm cert`) on top of PR #28 (`fix: vuln 0512`, commit `c861803`). PR #28 ran `go mod tidy` + `go mod vendor` and the vendor regeneration silently reverted PR #25's manual patches to:

- `vendor/knative.dev/pkg/webhook/webhook.go`
- `vendor/knative.dev/pkg/webhook/resourcesemantics/conversion/reconciler.go`

## Why

Tested on an ACP cluster with the `knative-operator.v3.20.9-hotfix.129.4.gd71ba5e5-fix-vuln-0512` CSV (`webhook:v1.10.1-c861803b`). `operator-webhook` Pod is `0/1 Running`, log loops:

```
operator-webhook   webhook/webhook.go:194   "server key missing"
operator-webhook   webhook/webhook.go:245   http: TLS handshake error from ...: tls: no certificates configured
operator-webhook.WebhookCertificates  certificates/certificates.go:78  Certificate secret "operator-webhook-service-cert" is missing key "server-key.pem"
operator-webhook.WebhookCertificates  controller/controller.go:566  Reconcile error  Secret "operator-webhook-service-cert" is invalid: [data[tls.crt]: Required value, data[tls.key]: Required value]
operator-webhook.ConversionWebhook    controller/controller.go:566  Reconcile error  secret "operator-webhook-service-cert" is missing "ca-cert.pem" key
```

OLM is populating `operator-webhook-service-cert` (type `kubernetes.io/tls`) with `tls.crt` / `tls.key` / `olmCAKey`, and the deployment sets `USE_OLM_TLS=true` + `WEBHOOK_SECRET_NAME=operator-webhook-service-cert`. But the binary in `c861803` has no `USE_OLM_TLS` code path — the vendor patches that introduced it were gone.

I verified the regression by fetching `vendor/knative.dev/pkg/webhook/webhook.go` at `c861803` via `gh api`: no `USE_OLM_TLS`, no `tls.key`/`tls.crt` branch. The diff in this PR is byte-for-byte the same as PR #25's diff.

## Follow-up (not in this PR)

Manual vendor patches will keep getting dropped by future `go mod vendor` runs (e.g. the next vuln-fix sweep). Recommend moving the OLM TLS support into a fork of `knative.dev/pkg` (e.g. AlaudaDevops/knative.dev.pkg or katanomi/knative-pkg) and pinning via `replace` in `go.mod`, so the patches survive vendor regeneration.

## Test plan

- [ ] Build a hotfix image from this branch
- [ ] Reinstall the operator on the test cluster
- [ ] Confirm `operator-webhook` Pod is `1/1 Running`, no `server key missing` / `tls: no certificates configured` in logs
- [ ] Confirm `ConversionWebhook` reconciles cleanly (no `operator-webhook-service-cert is missing "ca-cert.pem" key` errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)